### PR TITLE
ui/mpv: draw at correct size on high-dpi displays

### DIFF
--- a/bubblesub/ui/mpv.py
+++ b/bubblesub/ui/mpv.py
@@ -34,8 +34,8 @@ class MpvWidget(QOpenGLWidget):
         if self._opengl:
             self._opengl.draw(
                 self.defaultFramebufferObject(),
-                self.width(),
-                -self.height())
+                round(self.width() * self.devicePixelRatioF()),
+                round(-self.height() * self.devicePixelRatioF()))
 
     @QtCore.pyqtSlot()
     def swapped(self):


### PR DESCRIPTION
Without this, the video displays at e.g. 1/4 size in the corner on a 4K monitor. On a normal-dpi display, the devicePixelRatio will be 1 and it will draw as normal.

The choice of round instead of floor was based on guess-and-check. Using floor, there was sometimes a pixel-wide gap at the edge, so I believe that rounding matches how Qt decides on the size.

(`devicePixelRatioF()` requires Qt 5.6. Is that okay?)