### PR TITLE
build: depend on xdg module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'regex',
         'pyenchant',
         'pympv',
+        'xdg',
     ],
 
     classifiers=[


### PR DESCRIPTION
I think this was just forgotten? My distro (Arch) actually has a `python-xdg` package, which I had installed, that provides a *different* `xdg` module from the one required here, so the error message was a little non-intuitive. `pip install xdg` in a venv fixed it, so I think this is correct.