### PR TITLE
Disable useless commands at startup

### DIFF
--- a/bubblesub/cmd/audio_scroll_view.py
+++ b/bubblesub/cmd/audio_scroll_view.py
@@ -26,6 +26,10 @@ class AudioScrollViewCommand(BaseCommand):
         "Scrolls the spectrogram horizontally by its width's percentage."
     )
 
+    @property
+    def is_enabled(self) -> bool:
+        return self.api.media.is_loaded
+
     async def run(self) -> None:
         distance = int(self.args.delta * self.api.media.audio.view_size)
         self.api.media.audio.move_view(distance)

--- a/bubblesub/cmd/audio_shift_sel.py
+++ b/bubblesub/cmd/audio_shift_sel.py
@@ -30,6 +30,10 @@ class AudioShiftSelectionCommand(BaseCommand):
     ]
     help_text = "Shfits the spectrogram selection."
 
+    @property
+    def is_enabled(self) -> bool:
+        return self.api.media.is_loaded
+
     async def run(self) -> None:
         with self.api.undo.capture():
             start = self.api.media.audio.selection_start

--- a/bubblesub/cmd/audio_zoom_view.py
+++ b/bubblesub/cmd/audio_zoom_view.py
@@ -24,6 +24,10 @@ class AudioZoomViewCommand(BaseCommand):
     names = ["audio-zoom-view", "spectrogram-zoom-view"]
     help_text = "Zooms the spectrogram in or out by the specified factor."
 
+    @property
+    def is_enabled(self) -> bool:
+        return self.api.media.is_loaded
+
     async def run(self) -> None:
         mouse_x = 0.5
         cur_factor = self.api.media.audio.view_size / self.api.media.audio.size

--- a/bubblesub/cmd/common/sub_selection.py
+++ b/bubblesub/cmd/common/sub_selection.py
@@ -82,10 +82,10 @@ class SubtitlesSelection:
 
     @property
     def makes_sense(self) -> bool:
-        if self.target in {"all", "none"}:
-            return True
 
         if self.target in {
+            "all",
+            "none",
             "one-below",
             "one-above",
             "first",

--- a/bubblesub/cmd/set_playback_speed.py
+++ b/bubblesub/cmd/set_playback_speed.py
@@ -25,6 +25,10 @@ class SetPlaybackSpeedCommand(BaseCommand):
     names = ["set-playback-speed"]
     help_text = "Adjusts the video playback speed."
 
+    @property
+    def is_enabled(self) -> bool:
+        return self.api.media.is_loaded
+
     async def run(self) -> None:
         new_value = eval_expr(
             self.args.expression.format(self.api.media.playback_speed)

--- a/bubblesub/cmd/set_volume.py
+++ b/bubblesub/cmd/set_volume.py
@@ -25,6 +25,10 @@ class SetVolumeCommand(BaseCommand):
     names = ["set-volume"]
     help_text = "Adjusts the video volume."
 
+    @property
+    def is_enabled(self) -> bool:
+        return self.api.media.is_loaded
+
     async def run(self) -> None:
         new_value = eval_expr(
             self.args.expression.format(self.api.media.volume)


### PR DESCRIPTION
I guess it's better to disable commands that can't be used by the user when there are no media or subs. 