### PR TITLE
Fix crash when saving a screenshot

### DIFF
--- a/bubblesub/cmd/save_screenshot.py
+++ b/bubblesub/cmd/save_screenshot.py
@@ -35,6 +35,7 @@ class SaveScreenshotCommand(BaseCommand):
         return self.api.media.is_loaded
 
     async def run(self) -> None:
+        self.api.media.is_paused = True
         assert self.api.media.path
 
         pts = await self.args.pts.get()


### PR DESCRIPTION
It was inadvertently removed in one of the last commits. 