### PR TITLE
Add CI for bubblesub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+matrix:
+    include:
+        - os: linux
+          services: docker
+          dist: trusty
+          before_install:
+          - docker build -t bubblesub .
+          script:
+          - docker run -tid --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix bubblesub
+          - docker stop $( docker ps -a -q)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,112 @@
+FROM ubuntu:bionic
+
+MAINTAINER rr- "https://github.com/rr-"
+
+# Disable user-interaction
+ENV DEBIAN_FRONTEND noninteractive
+
+# List of system packages
+ENV SYSTEM="build-essential software-properties-common sudo locales \
+autoconf automake libtool git-core pkg-config wget nasm"
+
+# Prepare building machine
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends -y \
+        $SYSTEM
+
+# List of mpv packages
+ENV MPV="libegl1-mesa libgl1-mesa-glx libice6 libsm6 libx11-xcb1 libx11-6 \
+libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
+libxinerama1 libxrandr2 libxrender1 libxss1 libxtst6 libxv1 libasound2 \
+libbluray-dev libcaca0 libcdio-dev libcdio-cdda-dev libcdio-paranoia-dev \
+libdvdnav4 libdvdread4 libenca0 liblua5.2-dev liblua5.2-0 \
+libglu1-mesa-dev freeglut3-dev mesa-common-dev \
+libfontconfig1 libgstreamer-plugins-base1.0-dev libguess1 \
+libharfbuzz0b libicu60 libjack-jackd2-0 libjpeg-turbo8 liblua5.2-0 libpulse0 \
+libpython3.7 librubberband2 libsmbclient libuchardet0 libv4l-0 libvdpau1 \
+libwayland-egl1-mesa libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+libxcb-randr0 libxcb-render-util0 libxcb-render0 \
+libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-xfixes0 libxcb-xkb1 libxcb1 \
+libxkbcommon-x11-0 libxkbcommon0 libgnutlsxx28 libass-dev libsdl2-dev"
+
+# List of FFmpeg packages
+ENV FFMPEG="libavcodec-dev libavformat-dev libavdevice-dev"
+
+# List of bubblesub packages
+ENV BUBBLESUB="python3.7 python3.7-dev python3-pip python-enchant fftw3 qt5-default"
+
+# Install bubblesub's dependencies
+RUN add-apt-repository ppa:jonathonf/ffmpeg-4 && \
+    apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends -y \
+        $MPV $FFMPEG $BUBBLESUB
+
+# Cleanup
+RUN apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Disable git sslVerify
+RUN git config --global http.sslVerify false
+
+# Set Python environment
+RUN rm -f /usr/bin/python && \
+    ln -s /usr/bin/python3.7 /usr/bin/python && \
+    python -m pip install -U pip && \
+    pip install setuptools dataclasses
+
+# Install mpv
+RUN git clone --depth 1 https://github.com/mpv-player/mpv.git && \
+    cd mpv && \
+    ./bootstrap.py && \
+    ./waf configure \
+        --enable-libmpv-shared \
+        --disable-vdpau \
+        --disable-vulkan \
+        --disable-drm \
+        --disable-drmprime \
+        --disable-egl-drm \
+        --disable-vaapi-drm \
+        --enable-egl-x11 \
+        --enable-x11 && \
+    ./waf -j4 && \
+    ./waf install
+
+RUN cd ..
+
+# Install ffms2
+RUN git clone https://github.com/FFMS/ffms2.git && \
+    cd ffms2 && \
+    git checkout -b bubblesub-fix 2d3b4fa && \
+    ./autogen.sh && \
+    make && \
+    make install
+
+RUN cd ..
+
+# Install bubblesub
+RUN git clone --depth 1 https://github.com/rr-/bubblesub.git && \
+    cd bubblesub && \
+    locale-gen en_US.UTF-8 && \
+    export LC_ALL=en_US.UTF-8 && \
+    pip install .
+
+# Define a new user called bubblesub
+RUN export uid=1000 gid=1000 && \
+    mkdir -p /home/bubblesub && \
+    echo "bubblesub:x:${uid}:${gid}:Bubblesub,,,:/home/bubblesub:/bin/bash" >> /etc/passwd && \
+    echo "bubblesub:x:${uid}:" >> /etc/group && \
+    echo "bubblesub ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/bubblesub && \
+    chmod 0440 /etc/sudoers.d/bubblesub && \
+    chown ${uid}:${gid} -R /home/bubblesub
+
+# Set environment variables
+ENV HOME /home/bubblesub
+ENV PATH /usr/local/lib:$PATH
+ENV LD_CONFIG_PATH /usr/local/lib
+RUN ldconfig
+
+# Run bubblesub as user
+USER bubblesub
+
+# Launch bubblesub
+CMD bubblesub


### PR DESCRIPTION
Add continuous integration for `bubblesub`.

First off, a docker image is created using `Ubuntu 18.04 Bionic` as base image. All binaries necessary for the building process are installed and only `mpv` and `ffms2` (the ffms2000 branch) are built from scratch. Then `bubblesub` is installed. Finally, a new user, called bubblesub, is created, in this way it is possible to launch the GUI running the `docker run` command. 

Since it's is impossible to stop `bubblesub` inside the docker container because shell commands are disabled by `bubblesub` itself, the container is stopped using the `docker stop` command.

Each build takes on average 6 minutes in order to be performed. 