### PR TITLE
ci: build from code, not github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,6 @@ RUN git clone --depth 1 https://github.com/mpv-player/mpv.git && \
     ./waf -j4 && \
     ./waf install
 
-RUN cd ..
-
 # Install ffms2
 RUN git clone https://github.com/FFMS/ffms2.git && \
     cd ffms2 && \
@@ -81,17 +79,24 @@ RUN git clone https://github.com/FFMS/ffms2.git && \
     make && \
     make install
 
-RUN cd ..
+WORKDIR bubblesub
+
+# Install bubblesub dependencies
+RUN mkdir -p bubblesub && \
+    touch bubblesub/__init__.py
+COPY setup.py .
+COPY pyproject.toml .
+RUN locale-gen en_US.UTF-8 && \
+    export LC_ALL=en_US.UTF-8 && \
+    pip install -e .
 
 # Install bubblesub
-RUN git clone --depth 1 https://github.com/rr-/bubblesub.git && \
-    cd bubblesub && \
-    locale-gen en_US.UTF-8 && \
-    export LC_ALL=en_US.UTF-8 && \
-    pip install .
+COPY bubblesub bubblesub
+# ...but not local development garbage
+RUN find . -type d -name __pycache__ -exec rm -r {} \+
 
 # Find libffms2.so
 RUN ldconfig
 
 # Run pytest
-CMD pytest bubblesub/bubblesub/
+CMD pytest bubblesub/


### PR DESCRIPTION
`RUN cd ..` are useless since cwd is scoped to every `RUN` statement separately.

The proposed Dockerfile fakes a package, installs its dependencies, then copies the actual code over the faked package. It's done like this to avoid having to reinstall all dependencies after making small changes to the code.

Finally, it's important not to commit `__pycache__` into the docker image, since it contains different paths and that confuses python as hell.